### PR TITLE
chore(refresh): refreshed configuration and documentation

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -86,7 +86,7 @@ ixpert/
 │   └── copilot-instructions.md   # This file
 ├── Build/
 │   ├── iXpert.app/               # Pre-built application bundle (historical artifact)
-│   └── iXpert.ipa/               # Pre-built IPA (historical artifact)
+│   └── iXpert.ipa                # Pre-built IPA (historical artifact)
 ├── Imgs/
 │   ├── AccessoryView/            # Keyboard accessory bar background
 │   ├── Backgrounds/              # Per-mode background images (Hex, Bin, Oct, B64, MD5, …)
@@ -106,6 +106,8 @@ ixpert/
 │       ├── main.m
 │       ├── *.xib                        # Interface Builder layout files
 │       └── *.png                        # Runtime image assets
+├── .gitignore
+├── CHANGELOG.md
 ├── CONTRIBUTING.md
 ├── LICENSE
 └── README.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 
 ### Changed
 
+- refreshed `.github/copilot-instructions.md` repository structure to add `CHANGELOG.md`, `.gitignore`, and fix `Build/iXpert.ipa` entry
+
 ### Removed
 
 


### PR DESCRIPTION
Automated weekly refresh by `config-and-docs-refresh.yaml` in `rios0rios0/config-automation`.

Claude Code reviewed the in-scope configuration and documentation files (currently `CLAUDE.md` and `.github/copilot-instructions.md`) against the current code, updated whichever drifted, and recorded the change in `CHANGELOG.md` (when the repo has one).

Review the diff carefully --- this PR was generated by Claude Code and may contain inaccuracies.