### PR TITLE
chore(refresh): refreshed configuration and documentation

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -89,9 +89,8 @@ ixpert/
 │   └── iXpert.ipa                # Pre-built IPA (historical artifact)
 ├── Imgs/
 │   ├── AccessoryView/            # Keyboard accessory bar background
-│   ├── Backgrounds/              # Per-mode background images (Hex, Bin, Oct, B64, MD5, …)
+│   ├── Backgrounds/              # Per-mode background images + splash screens (Default.png)
 │   ├── Buttons/                  # Normal/selected states for all mode buttons + navigation
-│   ├── Default/                  # Splash screen images
 │   └── Icons/                    # App icons in multiple sizes + PSD sources
 ├── Project/
 │   ├── iXpert.xcodeproj/         # Xcode project file

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 
 ## [Unreleased]
 
+### Changed
+
+- refreshed `.github/copilot-instructions.md` to remove non-existent `Imgs/Default/` directory from repository structure
+
 ## [0.1.1] - 2026-05-19
 
 ### Changed


### PR DESCRIPTION
Automated weekly refresh by `config-and-docs-refresh.yaml` in `rios0rios0/config-automation`.

Claude Code reviewed the in-scope configuration and documentation files (currently `CLAUDE.md` and `.github/copilot-instructions.md`) against the current code, updated whichever drifted, and recorded the change in `CHANGELOG.md` (when the repo has one).

Review the diff carefully --- this PR was generated by Claude Code and may contain inaccuracies.